### PR TITLE
Add PreferChangeOverUpDownMigrations and prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.0
+
+- Add Igniter task to support installing via `mix igniter.install jump_credo_checks`,
+  courtesy of @britton-jb.
+- Add new `Jump.CredoChecks.PreferChangeOverUpDownMigrations` check, which detects
+  Ecto migrations that define separate `up`/`down` callbacks but could instead
+  take advantage of Ecto's automatic reversibility by using `change/0`.
+
 ## v0.1.0
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -72,8 +72,14 @@ See the individual modules for detailed descriptions of each check type.
     assert is_nil(error)
     assert %Product{} = result
     ```
+- `Jump.CredoChecks.PreferChangeOverUpDownMigrations`: Detects Ecto migrations which define separate `up`/`down`
+  callbacks but could instead take advantage of Ecto's automatic reversibility by using `change/0`.
+
 
 ## Installation and configuration
+
+**New in v0.2**: If you've already configured [Igniter](https://hexdocs.pm/igniter/) in your project,
+you can use `mix igniter.install jump_credo_checks` to automate all the steps in this section.
 
 The following instructions assume you already have Credo configured and working on your codebase.
 
@@ -82,7 +88,7 @@ The following instructions assume you already have Credo configured and working 
     ```elixir
     def deps do
       [
-        {:jump_credo_checks, "~> 0.1", only: [:dev], runtime: false},
+        {:jump_credo_checks, "~> 0.2", only: [:dev], runtime: false},
       ]
     end
     ```
@@ -116,6 +122,7 @@ The following instructions assume you already have Credo configured and working 
                ]},
               {Jump.CredoChecks.LiveViewFormCanBeRehydrated, excluded: ["lib/my_app/"]},
               # Default start_after is "0"
+              {Jump.CredoChecks.PreferChangeOverUpDownMigrations, start_after: "20240101000000"},
               {Jump.CredoChecks.PreferTextColumns, start_after: "20240101000000"},
               {Jump.CredoChecks.TestHasNoAssertions, custom_assertion_functions: [:await_has, :await_with_timeout]},
               # Default max_assertions is 20

--- a/lib/jump/credo_checks/prefer_change_over_up_down_migrations.ex
+++ b/lib/jump/credo_checks/prefer_change_over_up_down_migrations.ex
@@ -1,0 +1,190 @@
+defmodule Jump.CredoChecks.PreferChangeOverUpDownMigrations do
+  @moduledoc """
+  Ensures Ecto migrations take advantage of automatic reversibility where possible.
+
+  Detects Ecto migrations that define `up` and `down` callbacks even though
+  the `up` body is composed entirely of operations Ecto can automatically
+  reverse. In that case, both callbacks can be replaced by a single `change` callback.
+
+  For more information, see the [Ecto Migration docs](https://hexdocs.pm/ecto_sql/Ecto.Migration.html).
+  """
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :readability,
+    explanations: [
+      check: """
+      Ensures Ecto migrations take advantage of automatic reversibility where possible.
+
+      When every operation in an Ecto migration's `up` callback is one Ecto
+      knows how to reverse (`create`/`alter` table, `create` index, `add` /
+      `remove`-with-type / `modify`-with-`:from` columns, `rename`, etc.),
+      a separate `down` callback is redundant and can be replaced by a
+      single `change/0` callback.
+
+
+          # ❌ Bad
+          def up do
+            alter table(:integration_schemas) do
+              add :salesforce_record_types, :jsonb,
+                null: false,
+                default: fragment("'[]'::jsonb")
+            end
+          end
+
+          def down do
+            alter table(:integration_schemas) do
+              remove :salesforce_record_types
+            end
+          end
+
+          # ✅ Good
+          def change do
+            alter table(:integration_schemas) do
+              add :salesforce_record_types, :jsonb,
+                null: false,
+                default: fragment("'[]'::jsonb")
+            end
+          end
+
+      For more information, see the Ecto Migration docs:
+      https://hexdocs.pm/ecto_sql/Ecto.Migration.html
+      """
+    ],
+    param_defaults: [
+      start_after: "0",
+      excluded: []
+    ]
+
+  alias Credo.IssueMeta
+
+  def run(source_file, params) do
+    start_after = Params.get(params, :start_after, __MODULE__)
+    excluded = Params.get(params, :excluded, __MODULE__)
+
+    if relevant_file?(source_file.filename, start_after, excluded) do
+      issue_meta = IssueMeta.for(source_file, params)
+      Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    else
+      []
+    end
+  end
+
+  defp traverse({:defmodule, _, [_alias, [do: body]]} = ast, issues, issue_meta) do
+    statements = body_statements(body)
+    up_def = Enum.find(statements, &up_def?/1)
+    down_def = Enum.find(statements, &down_def?/1)
+
+    if up_def && down_def && up_def |> def_body() |> reversible_block?() do
+      {ast, [issue_for(issue_meta, def_line(up_def)) | issues]}
+    else
+      {ast, issues}
+    end
+  end
+
+  defp traverse(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp body_statements({:__block__, _, statements}), do: statements
+  defp body_statements(nil), do: []
+  defp body_statements(stmt), do: [stmt]
+
+  defp up_def?({:def, _, [{:up, _, _} | _]}), do: true
+  defp up_def?(_), do: false
+
+  defp down_def?({:def, _, [{:down, _, _} | _]}), do: true
+  defp down_def?(_), do: false
+
+  defp def_body({:def, _, [_head, [do: body]]}), do: body
+  defp def_body(_), do: nil
+
+  defp def_line({:def, meta, _}), do: meta[:line]
+
+  defp reversible_block?(nil), do: false
+
+  defp reversible_block?(body) do
+    body
+    |> body_statements()
+    |> Enum.all?(&reversible_statement?/1)
+  end
+
+  # `create table(:foo) do ... end` and `create_if_not_exists table(:foo) do ... end`
+  defp reversible_statement?({create, _, [{:table, _, _}, [do: _]]}) when create in [:create, :create_if_not_exists],
+    do: true
+
+  # `create table(...)`, `create index(...)`, `create unique_index(...)`,
+  # `create constraint(...)`, and the `create_if_not_exists` variants.
+  defp reversible_statement?({create, _, [{call, _, _}]})
+       when create in [:create, :create_if_not_exists] and call in [:table, :index, :unique_index, :constraint],
+       do: true
+
+  # `drop index(...)`, `drop unique_index(...)`, and the `drop_if_exists` variants.
+  defp reversible_statement?({drop, _, [{call, _, _}]})
+       when drop in [:drop, :drop_if_exists] and call in [:index, :unique_index], do: true
+
+  defp reversible_statement?({drop, _, [{call, _, _}, opts]})
+       when drop in [:drop, :drop_if_exists] and call in [:index, :unique_index] and is_list(opts), do: true
+
+  # `alter table(:foo) do ... end` is reversible iff every inner op is.
+  defp reversible_statement?({:alter, _, [{:table, _, _}, [do: body]]}) do
+    body
+    |> body_statements()
+    |> Enum.all?(&reversible_alter_inner?/1)
+  end
+
+  # `rename table(:foo), to: table(:bar)`
+  defp reversible_statement?({:rename, _, [{:table, _, _}, [to: {:table, _, _}]]}), do: true
+
+  # `rename index(:foo, [:bar]), to: "new_index_name"`
+  defp reversible_statement?({:rename, _, [{call, _, _}, [to: _new_name]]}) when call in [:index, :unique_index],
+    do: true
+
+  # `rename table(:foo), :col, to: :new_col`
+  defp reversible_statement?({:rename, _, [{:table, _, _}, col, [to: new_col]]}) when is_atom(col) and is_atom(new_col),
+    do: true
+
+  # `execute(up_sql, down_sql)` and `execute_file(up_path, down_path)` use explicit reverse pairs.
+  defp reversible_statement?({execute, _, args}) when execute in [:execute, :execute_file] and length(args) == 2,
+    do: true
+
+  defp reversible_statement?(_), do: false
+
+  # Inside `alter table do ... end`:
+
+  # `add :col, :type` and `add :col, :type, opts`
+  defp reversible_alter_inner?({:add, _, args}) when length(args) in [2, 3], do: true
+
+  # `remove :col, :type` and `remove :col, :type, opts` — needs the type to be reversible.
+  defp reversible_alter_inner?({:remove, _, args}) when length(args) in [2, 3], do: true
+
+  # `modify :col, :type, opts` — only reversible when opts include `:from`.
+  defp reversible_alter_inner?({:modify, _, [_col, _type, opts]}) when is_list(opts) do
+    not is_nil(Keyword.get(opts, :from))
+  end
+
+  # `timestamps()` expands to two `add` calls and is reversible.
+  defp reversible_alter_inner?({:timestamps, _, _}), do: true
+
+  defp reversible_alter_inner?(_), do: false
+
+  defp issue_for(issue_meta, line_no) do
+    format_issue(issue_meta,
+      message:
+        "This migration's `up` body is composed entirely of operations Ecto can reverse automatically; " <>
+          "you can rename your `up` callback to `change/0` and delete `down` entirely.",
+      trigger: "def up",
+      line_no: line_no
+    )
+  end
+
+  defp relevant_file?(path, start_after, excluded) do
+    String.starts_with?(path, "priv") and String.contains?(path, "migrations") and
+      migration_timestamp(path) > start_after and not String.contains?(path, excluded)
+  end
+
+  defp migration_timestamp(path) do
+    path
+    |> Path.basename()
+    |> String.split("_")
+    |> hd()
+  end
+end

--- a/lib/mix/tasks/jump_credo_checks.install.ex
+++ b/lib/mix/tasks/jump_credo_checks.install.ex
@@ -30,6 +30,7 @@ if Code.ensure_loaded?(Igniter) do
     alias Jump.CredoChecks.DoctestIExExamples
     alias Jump.CredoChecks.ForbiddenFunction
     alias Jump.CredoChecks.LiveViewFormCanBeRehydrated
+    alias Jump.CredoChecks.PreferChangeOverUpDownMigrations
     alias Jump.CredoChecks.PreferTextColumns
     alias Jump.CredoChecks.TestHasNoAssertions
     alias Jump.CredoChecks.TooManyAssertions
@@ -46,6 +47,7 @@ if Code.ensure_loaded?(Igniter) do
       DoctestIExExamples,
       ForbiddenFunction,
       LiveViewFormCanBeRehydrated,
+      PreferChangeOverUpDownMigrations,
       PreferTextColumns,
       TestHasNoAssertions,
       TooManyAssertions,

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Jump.CredoChecks.MixProject do
   def project do
     [
       app: :jump_credo_checks,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.18",
       consolidate_protocols: Mix.env() != :test,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/jump/credo_checks/prefer_change_over_up_down_migrations_test.exs
+++ b/test/jump/credo_checks/prefer_change_over_up_down_migrations_test.exs
@@ -1,0 +1,599 @@
+defmodule Jump.CredoChecks.PreferChangeOverUpDownMigrationsTest do
+  use Credo.Test.Case, async: true
+
+  alias Jump.CredoChecks.PreferChangeOverUpDownMigrations
+
+  test "flags up + down using alter table with add" do
+    """
+    defmodule MyApp.Repo.Migrations.AddSalesforceRecordTypes do
+      use Ecto.Migration
+
+      def up do
+        alter table(:integration_schemas) do
+          add :salesforce_record_types, :jsonb,
+            null: false,
+            default: fragment("'[]'::jsonb")
+        end
+      end
+
+      def down do
+        alter table(:integration_schemas) do
+          remove :salesforce_record_types
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000001_add_salesforce_record_types.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "def up"
+      assert issue.message =~ "change/0"
+    end)
+  end
+
+  test "flags up + down with create table" do
+    """
+    defmodule MyApp.Repo.Migrations.CreateUsers do
+      use Ecto.Migration
+
+      def up do
+        create table(:users) do
+          add :email, :text, null: false
+          timestamps()
+        end
+      end
+
+      def down do
+        drop table(:users)
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000002_create_users.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with create_if_not_exists table" do
+    """
+    defmodule MyApp.Repo.Migrations.CreateUsersIfNotExists do
+      use Ecto.Migration
+
+      def up do
+        create_if_not_exists table(:users) do
+          add :email, :text, null: false
+        end
+      end
+
+      def down do
+        drop_if_exists table(:users)
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000003_create_users_if_not_exists.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with create index" do
+    """
+    defmodule MyApp.Repo.Migrations.AddIndex do
+      use Ecto.Migration
+
+      def up do
+        create index(:users, [:email])
+      end
+
+      def down do
+        drop index(:users, [:email])
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000004_add_index.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with drop index" do
+    """
+    defmodule MyApp.Repo.Migrations.RemoveIndex do
+      use Ecto.Migration
+
+      def up do
+        drop index(:users, [:email])
+      end
+
+      def down do
+        create index(:users, [:email])
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000023_remove_index.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with drop_if_exists index" do
+    """
+    defmodule MyApp.Repo.Migrations.RemoveIndexIfExists do
+      use Ecto.Migration
+
+      def up do
+        drop_if_exists index(:users, [:email])
+      end
+
+      def down do
+        create_if_not_exists index(:users, [:email])
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000024_remove_index_if_exists.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with create unique_index" do
+    """
+    defmodule MyApp.Repo.Migrations.AddUniqueIndex do
+      use Ecto.Migration
+
+      def up do
+        create unique_index(:users, [:email])
+      end
+
+      def down do
+        drop unique_index(:users, [:email])
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000005_add_unique_index.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with create constraint" do
+    """
+    defmodule MyApp.Repo.Migrations.AddCheck do
+      use Ecto.Migration
+
+      def up do
+        create constraint("users", :age_must_be_positive, check: "age > 0")
+      end
+
+      def down do
+        drop constraint("users", :age_must_be_positive)
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000006_add_check.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with rename column" do
+    """
+    defmodule MyApp.Repo.Migrations.RenameColumn do
+      use Ecto.Migration
+
+      def up do
+        rename table(:users), :name, to: :full_name
+      end
+
+      def down do
+        rename table(:users), :full_name, to: :name
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000007_rename_column.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with rename table" do
+    """
+    defmodule MyApp.Repo.Migrations.RenameTable do
+      use Ecto.Migration
+
+      def up do
+        rename table(:posts), to: table(:articles)
+      end
+
+      def down do
+        rename table(:articles), to: table(:posts)
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000008_rename_table.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with rename index" do
+    """
+    defmodule MyApp.Repo.Migrations.RenameIndex do
+      use Ecto.Migration
+
+      def up do
+        rename index(:people, [:name], name: "persons_name_index"), to: "people_name_index"
+      end
+
+      def down do
+        rename index(:people, [:name], name: "people_name_index"), to: "persons_name_index"
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000025_rename_index.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with modify and from option" do
+    """
+    defmodule MyApp.Repo.Migrations.ChangeType do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          modify :age, :integer, from: :string
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          modify :age, :string, from: :integer
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000009_change_type.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with multiple reversible operations" do
+    """
+    defmodule MyApp.Repo.Migrations.MultiOp do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          add :age, :integer
+        end
+
+        create index(:users, [:age])
+      end
+
+      def down do
+        drop index(:users, [:age])
+
+        alter table(:users) do
+          remove :age, :integer
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000010_multi_op.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with execute/2 (explicit reverse)" do
+    """
+    defmodule MyApp.Repo.Migrations.ExplicitReverse do
+      use Ecto.Migration
+
+      def up do
+        execute "CREATE EXTENSION pgcrypto", "DROP EXTENSION pgcrypto"
+      end
+
+      def down do
+        execute "DROP EXTENSION pgcrypto", "CREATE EXTENSION pgcrypto"
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000011_explicit_reverse.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with execute_file/2 (explicit reverse)" do
+    """
+    defmodule MyApp.Repo.Migrations.ExplicitReverseFile do
+      use Ecto.Migration
+
+      def up do
+        execute_file "up.sql", "down.sql"
+      end
+
+      def down do
+        execute_file "down.sql", "up.sql"
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000026_explicit_reverse_file.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "flags up + down with remove that includes type" do
+    """
+    defmodule MyApp.Repo.Migrations.RemoveCol do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          remove :legacy_flag, :boolean, default: false
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          add :legacy_flag, :boolean, default: false
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000012_remove_col.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> assert_issue()
+  end
+
+  test "does not flag when up uses add_if_not_exists (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.AddColIfNotExists do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          add_if_not_exists :nickname, :text
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          remove_if_exists :nickname
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000027_add_col_if_not_exists.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses remove_if_exists with type (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.RemoveColIfExists do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          remove_if_exists :nickname, :text
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          add_if_not_exists :nickname, :text
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000028_remove_col_if_exists.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses raw execute/1 (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.AddIndexConcurrently do
+      use Ecto.Migration
+
+      def up do
+        execute "CREATE INDEX CONCURRENTLY idx_users_email ON users (email)"
+      end
+
+      def down do
+        execute "DROP INDEX idx_users_email"
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000013_add_index_concurrently.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses drop (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.DropTable do
+      use Ecto.Migration
+
+      def up do
+        drop table(:users)
+      end
+
+      def down do
+        create table(:users) do
+          add :email, :text
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000014_drop_table.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses remove without type (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.RemoveColWithoutType do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          remove :legacy
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          add :legacy, :text
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000015_remove_col_without_type.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses modify without :from (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.ModifyCol do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          modify :age, :integer
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          modify :age, :string
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000016_modify_col.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up uses modify with nil :from (not auto-reversible)" do
+    """
+    defmodule MyApp.Repo.Migrations.ModifyColFromNil do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          modify :age, :integer, from: nil
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          modify :age, :string, from: :integer
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000029_modify_col_from_nil.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up mixes reversible ops with raw execute/1" do
+    """
+    defmodule MyApp.Repo.Migrations.AddAndBackfill do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          add :status, :text
+        end
+
+        execute "UPDATE users SET status = 'active'"
+      end
+
+      def down do
+        alter table(:users) do
+          remove :status, :text
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000017_add_and_backfill.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when only change is defined" do
+    """
+    defmodule MyApp.Repo.Migrations.AddIt do
+      use Ecto.Migration
+
+      def change do
+        alter table(:users) do
+          add :age, :integer
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000018_add_it.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when only up is defined (no down)" do
+    """
+    defmodule MyApp.Repo.Migrations.UpOnly do
+      use Ecto.Migration
+
+      def up do
+        alter table(:users) do
+          add :age, :integer
+        end
+      end
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000019_up_only.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag when up calls arbitrary helper functions" do
+    """
+    defmodule MyApp.Repo.Migrations.ArbitraryCalls do
+      use Ecto.Migration
+
+      def up do
+        do_some_setup()
+
+        alter table(:users) do
+          add :age, :integer
+        end
+      end
+
+      def down do
+        alter table(:users) do
+          remove :age, :integer
+        end
+      end
+
+      defp do_some_setup, do: :ok
+    end
+    """
+    |> to_source_file("priv/repo/migrations/20260101000020_arbitrary_calls.exs")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+
+  test "does not flag in non-migration files" do
+    """
+    defmodule MyApp.Other do
+      def up do
+        alter_state()
+      end
+
+      def down do
+        alter_state()
+      end
+
+      defp alter_state, do: :ok
+    end
+    """
+    |> to_source_file("lib/my_app/other.ex")
+    |> run_check(PreferChangeOverUpDownMigrations)
+    |> refute_issues()
+  end
+end

--- a/test/jump/mix/tasks/jump_credo_checks_install_test.exs
+++ b/test/jump/mix/tasks/jump_credo_checks_install_test.exs
@@ -54,6 +54,7 @@ defmodule Mix.Tasks.JumpCredoChecks.InstallTest do
       + |{Jump.CredoChecks.DoctestIExExamples, []},
       + |{Jump.CredoChecks.ForbiddenFunction, []},
       + |{Jump.CredoChecks.LiveViewFormCanBeRehydrated, []},
+      + |{Jump.CredoChecks.PreferChangeOverUpDownMigrations, []},
       + |{Jump.CredoChecks.PreferTextColumns, []},
       + |{Jump.CredoChecks.TestHasNoAssertions, []},
       + |{Jump.CredoChecks.TooManyAssertions, []},


### PR DESCRIPTION
Adds a new `Jump.CredoChecks.PreferChangeOverUpDownMigrations` check, which detects Ecto migrations that define separate `up`/`down` callbacks but could instead take advantage of Ecto's automatic reversibility by using `change/0`.