### PR TITLE
feat: Add ConditionalAssertion check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -71,6 +71,7 @@
           {Jump.CredoChecks.AvoidLoggerConfigureInTest, []},
           # Default exclusion list is empty
           {Jump.CredoChecks.AvoidSocketAssignsInTest, excluded: ["test/app_web/plugs/"]},
+          {Jump.CredoChecks.ConditionalAssertion, []},
           {Jump.CredoChecks.DoctestIExExamples,
            [
              # Tells Credo where to look for the `doctest` call.
@@ -87,12 +88,14 @@
              {:erlang, :binary_to_term, "Use Plug.Crypto.non_executable_binary_to_term/2 instead."}
            ]},
           {Jump.CredoChecks.LiveViewFormCanBeRehydrated, excluded: ["lib/my_app/"]},
+          {Jump.CredoChecks.PreferChangeOverUpDownMigrations, start_after: "20240101000000"},
           # Default start_after is "0"
           {Jump.CredoChecks.PreferTextColumns, start_after: "20240101000000"},
           {Jump.CredoChecks.TestHasNoAssertions, custom_assertion_functions: [:await_has, :await_with_timeout]},
           # Default max_assertions is 20
           {Jump.CredoChecks.TooManyAssertions, [max_assertions: 20]},
           {Jump.CredoChecks.TopLevelAliasImportRequire, []},
+          {Jump.CredoChecks.UnusedLiveViewAssign, [ignored_assigns: [:active_path]]},
           {Jump.CredoChecks.UseObanProWorker, []},
           {Jump.CredoChecks.VacuousTest,
            [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ It's helpful if they can also point you to a specific place in the codebase wher
 3. You should always write the tests first (at `test/jump/credo_checks/*_test.exs`); test-driven development is by far the superior way to work with this stuff.
 4. Feel free to add temporary debugging output (`IO.inspect`, `dbg`, etc.) to the check and repeatedly rerun the tests to figure out what the AST looks like in the cases you care about.
 5. When your tests are all passing, add the check to the list of custom configured checks in @.credo.exs and run the `mix credo` task. The command should produce no warnings; if it does, ask the user how to proceed.
+6. Update the README (both in the "Available Checks" and "Installation and configuration" sections), and add the new check to the CHANGELOG for the next release
 
 # References
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.4.0
+
+* New check: Add `Jump.CredoChecks.ConditionalAssertion`, which flags assertions that include an "or." Tests should be able to confidently assert which branch will be taken every time.
+
 ## v0.3.0
 
 * New check: Add `Jump.CredoChecks.UnusedLiveViewAssign`, compliments of first-time contributor @ftes ([PR](https://github.com/Jump-App/credo_checks/pull/9))

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the individual modules for detailed descriptions of each check type.
     ```
 - `Jump.CredoChecks.AvoidLoggerConfigureInTest`: Ensure your tests don't call `Logger.configure/1` and thereby affect log levels for other tests.
 - `Jump.CredoChecks.AvoidSocketAssignsInTest`: Ensure that tests assert on expected user behavior rather than introspecting socket `assigns`.
+- `Jump.CredoChecks.ConditionalAssertion`: Flags assertions that include an "or," like `assert foo == :bar or baz == :bop` or `assert foo > 0 || bop > 0`.
 - `Jump.CredoChecks.DoctestIExExamples`: Ensures that modules with interactive Elixir examples in their docstrings have a corresponding test file that runs those doctests.
 - `Jump.CredoChecks.ForbiddenFunction`: Alerts with a custom error message when particular functions are called.
 - `Jump.CredoChecks.LiveViewFormCanBeRehydrated`: Ensures any form with a `phx-submit` attribute also includes an ID and `phx-change` handler. Without these, LiveView can't maintain frontend form state across deploys/reconnects, leading to the form being totally reset.
@@ -107,6 +108,7 @@ The following instructions assume you already have Credo configured and working 
               {Jump.CredoChecks.AvoidLoggerConfigureInTest, []},
               # Default exclusion list is empty
               {Jump.CredoChecks.AvoidSocketAssignsInTest, excluded: ["test/app_web/plugs/"]},
+              {Jump.CredoChecks.ConditionalAssertion, []},
               {Jump.CredoChecks.DoctestIExExamples, [
                 # Tells Credo where to look for the `doctest` call.
                 # If you colocate your test files with your implementation, this would just

--- a/lib/jump/credo_checks/conditional_assertion.ex
+++ b/lib/jump/credo_checks/conditional_assertion.ex
@@ -1,0 +1,55 @@
+defmodule Jump.CredoChecks.ConditionalAssertion do
+  @moduledoc """
+  Flags `assert` calls whose top-level expression is a boolean `or`/`||`,
+  since those make the test non-deterministic.
+  """
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      Tests should be deterministic: you should be able to confidently say which
+      branch will be taken every time the test runs. An assertion of the form
+      `assert a or b` (or `assert a || b`) indicates you don't really know what's
+      going on in your test.
+
+      If you genuinely don't know which value to expect, that's a signal the test
+      setup is non-deterministic; fix the source of the non-determinism instead
+      of papering over it in the assertion.
+
+          # ❌ Non-deterministic
+          assert foo == :bar or baz == :bop
+          assert foo in [:bar, :baz] || bop in [:whiz, :bang]
+
+          # ✅ Deterministic
+          assert foo == :bar
+          assert bop in [:whiz, :bang]
+      """
+    ]
+
+  alias Credo.IssueMeta
+
+  @doc false
+  @impl Credo.Check
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:assert, meta, [{op, _, [_, _]} = expr | _rest]} = ast, issues, issue_meta) when op in [:or, :||] do
+    {ast, [issue_for(issue_meta, Macro.to_string(expr), meta[:line]) | issues]}
+  end
+
+  defp traverse(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp issue_for(issue_meta, trigger, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "Asserting on an `or`/`||` expression makes the test non-deterministic — it passes for either branch. Assert the specific value you expect.",
+      trigger: trigger,
+      line_no: line_no
+    )
+  end
+end

--- a/test/jump/credo_checks/conditional_assertion_test.exs
+++ b/test/jump/credo_checks/conditional_assertion_test.exs
@@ -1,0 +1,65 @@
+defmodule Jump.CredoChecks.ConditionalAssertionTest do
+  use Credo.Test.Case, async: true
+
+  alias Jump.CredoChecks.ConditionalAssertion
+
+  describe "flags non-deterministic assertions" do
+    for assertion <- [
+          "assert foo == :bar or baz == :bop",
+          "assert foo == :bar || baz == :bop",
+          "assert foo in [:bar, :baz] or bop in [:whiz, :bang]",
+          "assert foo in [:bar, :baz] || bop in [:whiz, :bang]",
+          "assert (foo =~ \"bar\") or (baz * 10 + 4 < 0)",
+          "assert a or b or c",
+          "assert a || b || c",
+          "assert a or b, \"custom message\"",
+          "assert a || b, \"custom message\""
+        ] do
+      @tag assertion: assertion
+      test "flags `#{assertion}`", %{assertion: assertion} do
+        """
+        defmodule MyTest do
+          use ExUnit.Case, async: true
+
+          test "non-deterministic" do
+            #{assertion}
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(ConditionalAssertion)
+        |> assert_issue(fn issue ->
+          assert issue.message =~ "deterministic"
+        end)
+      end
+    end
+  end
+
+  describe "does not flag deterministic assertions" do
+    for assertion <- [
+          "assert foo == :bar",
+          "assert foo == :bar and baz == :bop",
+          "assert foo == :bar && baz == :bop",
+          "assert foo in [:bar, :baz]",
+          "assert Enum.any?(list, fn x -> x == 1 or x == 2 end)",
+          "assert match?({:ok, _}, result)",
+          "assert true"
+        ] do
+      @tag assertion: assertion
+      test "does not flag `#{assertion}`", %{assertion: assertion} do
+        """
+        defmodule MyTest do
+          use ExUnit.Case, async: true
+
+          test "deterministic" do
+            #{assertion}
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(ConditionalAssertion)
+        |> refute_issues()
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a new check to ensure that our assertions don't contain "or" clauses. These are almost always an anti-pattern, but LLMs love to generate them.


Example:

```
assert html =~ "Loading" or html =~ "Loaded"
```

<img width="500" height="281" alt="which-one" src="https://github.com/user-attachments/assets/bdabfc03-b703-411f-9a9c-bf8aaf9e8d0f" />
