### PR TITLE
feat: Add AssertReceiveTimeout check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -67,6 +67,9 @@
       checks: %{
         enabled: [
           {Jump.CredoChecks.AssertElementSelectorCanNeverFail, []},
+          # Default min_assert_receive_timeout and max_refute_receive_timeout are both nil
+          # (any explicit assert_receive timeout is flagged; refute_receive timeouts are not checked)
+          {Jump.CredoChecks.AssertReceiveTimeout, min_assert_receive_timeout: 1_000, max_refute_receive_timeout: 100},
           {Jump.CredoChecks.AvoidFunctionLevelElse, []},
           {Jump.CredoChecks.AvoidLoggerConfigureInTest, []},
           # Default exclusion list is empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## v0.4.0
 
-* New check: Add `Jump.CredoChecks.ConditionalAssertion`, which flags assertions that include an "or." Tests should be able to confidently assert which branch will be taken every time.
+* New checks:
+    * `Jump.CredoChecks.AssertReceiveTimeout`, which flags `assert_receive` calls that specify an explicit timeout. Supports an optional `min_assert_receive_timeout` parameter that allows literal `assert_receive` timeouts greater than or equal to the configured minimum, and an optional `max_refute_receive_timeout` parameter that flags `refute_receive` calls whose timeout exceeds the configured maximum. ([PR](https://github.com/Jump-App/credo_checks/pull/16))
+    * `Jump.CredoChecks.ConditionalAssertion`, which flags assertions that include an "or." Tests should be able to confidently assert which branch will be taken every time. ([PR](https://github.com/Jump-App/credo_checks/pull/15))
 
 ## v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ These are checks used internally by [Jump](https://jump.ai/)'s engineering team,
 See the individual modules for detailed descriptions of each check type.
 
 - `Jump.CredoChecks.AssertElementSelectorCanNeverFail`: Prevents asserting on a `LiveViewTest.element/{2,3}` call, which can never fail since the function always returns a (possibly empty) list.
+- `Jump.CredoChecks.AssertReceiveTimeout`: Flags `assert_receive` calls that specify explicit timeouts. These timeouts can seem like a fine idea in dev, but when your test later runs on a dog-slow CI machine, the tight timeouts can cause flakiness. (In CI, you might run with an absurdly long timeout to avoid flakiness.)
+    - Supports an optional `min_assert_receive_timeout` parameter that allows literal `assert_receive` timeouts greater than or equal to the configured minimum
+    - Also supports an optional `max_refute_receive_timeout` parameter that flags `refute_receive` calls whose timeout exceeds the configured maximum (because `refute_receive` always blocks for its full timeout, setting a lower bound on the test's runtime)
 - `Jump.CredoChecks.AvoidFunctionLevelElse`: Prevents botched refactors or rebases from introducing `else` clauses at the top level of a function body.
 
     ```elixir
@@ -104,6 +107,16 @@ The following instructions assume you already have Credo configured and working 
           checks: %{
             enabled: [
               {Jump.CredoChecks.AssertElementSelectorCanNeverFail, []},
+              # Default min_assert_receive_timeout and max_refute_receive_timeout are both nil
+              # (any explicit assert_receive timeout is flagged; refute_receive timeouts are not checked).
+              # - Set min_assert_receive_timeout to allow explicit assert_receive timeouts that are
+              #   integer literals >= the configured value.
+              # - Set max_refute_receive_timeout to flag refute_receive calls with timeouts longer than
+              #   the configured value. Because refute_receive always blocks for its full timeout, a long
+              #   refute_receive sets a lower bound on how long the entire test takes to run.
+              {Jump.CredoChecks.AssertReceiveTimeout,
+                min_assert_receive_timeout: 1_000,
+                max_refute_receive_timeout: 100},
               {Jump.CredoChecks.AvoidFunctionLevelElse, []},
               {Jump.CredoChecks.AvoidLoggerConfigureInTest, []},
               # Default exclusion list is empty

--- a/lib/jump/credo_checks/assert_receive_timeout.ex
+++ b/lib/jump/credo_checks/assert_receive_timeout.ex
@@ -1,0 +1,165 @@
+defmodule Jump.CredoChecks.AssertReceiveTimeout do
+  @moduledoc """
+  Flags `assert_receive` calls that specify an explicit timeout, and optionally
+  `refute_receive` calls whose timeout exceeds a configured maximum.
+  """
+
+  use Credo.Check,
+    base_priority: :normal,
+    category: :warning,
+    param_defaults: [min_assert_receive_timeout: nil, max_refute_receive_timeout: nil],
+    explanations: [
+      check: """
+      Tests should rely on the default `:ex_unit` `:assert_receive_timeout` rather than
+      specifying their own. Custom timeouts inflate suite duration when the message
+      never arrives and tend to drift higher over time as people paper over flaky tests.
+
+          # ❌ Bad — explicit timeout
+          assert_receive :foo, 1_000
+
+          # ✅ Good — rely on the configured default
+          assert_receive :foo
+
+      If you want to be able to specify a *longer* timeout than default, configure
+      this check with a `min_assert_receive_timeout` to enforce a floor; any literal
+      timeout at or above the minimum will be allowed, and omitting the timeout
+      entirely (falling back to ExUnit's default) is always allowed.
+
+      Additionally, you can configure `max_refute_receive_timeout` to cap how long
+      a `refute_receive` is allowed to block. Because `refute_receive` *always* waits
+      its full timeout (including ExUnit's default when none is specified), the
+      timeout sets a *minimum* bound on how long the test takes to run. When this
+      param is set, every `refute_receive` must specify an explicit literal timeout
+      at or below the configured maximum — bare `refute_receive` calls are flagged
+      too, since they fall back to a default that also blocks the test.
+      """,
+      params: [
+        min_assert_receive_timeout:
+          "If set, allows explicit `assert_receive` timeouts that are an integer literal greater than or equal to this value. " <>
+            "Defaults to `nil` (no explicit timeout allowed). As with the built-in timeout type, units are milliseconds.",
+        max_refute_receive_timeout:
+          "If set, flags `refute_receive` calls whose timeout is an integer literal greater than this value, " <>
+            "whose timeout cannot be statically verified, or which omit an explicit timeout entirely. " <>
+            "Defaults to `nil` (no `refute_receive` timeout is flagged). As with the built-in timeout type, units are milliseconds."
+      ]
+    ]
+
+  alias Credo.IssueMeta
+
+  @doc false
+  @impl Credo.Check
+  def run(source_file, params \\ []) do
+    issue_meta = IssueMeta.for(source_file, params)
+    min_assert = Params.get(params, :min_assert_receive_timeout, __MODULE__)
+    max_refute = Params.get(params, :max_refute_receive_timeout, __MODULE__)
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta, min_assert, max_refute))
+  end
+
+  # assert_receive pattern, timeout
+  defp traverse({:assert_receive, meta, [_pattern, timeout]} = ast, issues, issue_meta, min_assert, _max_refute) do
+    maybe_add_assert_issue(ast, issues, issue_meta, min_assert, timeout, meta)
+  end
+
+  # assert_receive pattern, timeout, failure_message
+  defp traverse(
+         {:assert_receive, meta, [_pattern, timeout, _failure_message]} = ast,
+         issues,
+         issue_meta,
+         min_assert,
+         _max_refute
+       ) do
+    maybe_add_assert_issue(ast, issues, issue_meta, min_assert, timeout, meta)
+  end
+
+  # refute_receive pattern (no explicit timeout — ExUnit's default still blocks the test for its full duration)
+  defp traverse({:refute_receive, meta, [_pattern]} = ast, issues, issue_meta, _min_assert, max_refute) do
+    maybe_add_refute_issue(ast, issues, issue_meta, max_refute, :no_timeout, meta)
+  end
+
+  # refute_receive pattern, timeout
+  defp traverse({:refute_receive, meta, [_pattern, timeout]} = ast, issues, issue_meta, _min_assert, max_refute) do
+    maybe_add_refute_issue(ast, issues, issue_meta, max_refute, timeout, meta)
+  end
+
+  # refute_receive pattern, timeout, failure_message
+  defp traverse(
+         {:refute_receive, meta, [_pattern, timeout, _failure_message]} = ast,
+         issues,
+         issue_meta,
+         _min_assert,
+         max_refute
+       ) do
+    maybe_add_refute_issue(ast, issues, issue_meta, max_refute, timeout, meta)
+  end
+
+  defp traverse(ast, issues, _issue_meta, _min_assert, _max_refute), do: {ast, issues}
+
+  defp maybe_add_assert_issue(ast, issues, issue_meta, min_assert, timeout, meta) do
+    if assert_allowed?(timeout, min_assert) do
+      {ast, issues}
+    else
+      {ast, [assert_issue_for(issue_meta, min_assert, timeout, meta[:line]) | issues]}
+    end
+  end
+
+  defp maybe_add_refute_issue(ast, issues, _issue_meta, nil, _timeout, _meta), do: {ast, issues}
+
+  defp maybe_add_refute_issue(ast, issues, issue_meta, max_refute, timeout, meta) do
+    if refute_allowed?(timeout, max_refute) do
+      {ast, issues}
+    else
+      {ast, [refute_issue_for(issue_meta, max_refute, timeout, meta[:line]) | issues]}
+    end
+  end
+
+  defp assert_allowed?(_timeout, nil), do: false
+  defp assert_allowed?(timeout, min_assert) when is_integer(timeout), do: timeout >= min_assert
+  defp assert_allowed?(_timeout, _min_assert), do: false
+
+  defp refute_allowed?(timeout, max_refute) when is_integer(timeout), do: timeout <= max_refute
+  defp refute_allowed?(_timeout, _max_refute), do: false
+
+  defp assert_issue_for(issue_meta, nil, timeout, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "Avoid specifying an explicit `assert_receive` timeout. Omit the timeout to use ExUnit's configured default.",
+      trigger: Macro.to_string(timeout),
+      line_no: line_no
+    )
+  end
+
+  defp assert_issue_for(issue_meta, min_assert, timeout, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "`assert_receive` timeout must be a literal integer >= #{min_assert}, or omitted entirely to use ExUnit's configured default.",
+      trigger: Macro.to_string(timeout),
+      line_no: line_no
+    )
+  end
+
+  defp refute_issue_for(issue_meta, max_refute, :no_timeout, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "`refute_receive` must specify an explicit timeout <= #{max_refute}. " <>
+          "`refute_receive` always blocks for its full timeout (including ExUnit's default), setting a minimum bound " <>
+          "on the entire test's runtime, so any `refute_receive` slows down the whole test suite.",
+      trigger: "refute_receive",
+      line_no: line_no
+    )
+  end
+
+  defp refute_issue_for(issue_meta, max_refute, timeout, line_no) do
+    format_issue(
+      issue_meta,
+      message:
+        "`refute_receive` timeout must be a literal integer <= #{max_refute}. " <>
+          "`refute_receive` always blocks for its full timeout, setting a minimum bound on the entire test's runtime, " <>
+          "so long `refute_receive` calls slow down the whole test suite.",
+      trigger: Macro.to_string(timeout),
+      line_no: line_no
+    )
+  end
+end

--- a/test/jump/credo_checks/assert_receive_timeout_test.exs
+++ b/test/jump/credo_checks/assert_receive_timeout_test.exs
@@ -1,0 +1,326 @@
+defmodule Jump.CredoChecks.AssertReceiveTimeoutTest do
+  use Credo.Test.Case, async: true
+
+  alias Jump.CredoChecks.AssertReceiveTimeout
+
+  describe "without a configured min_assert_receive_timeout" do
+    test "alerts on assert_receive with a literal timeout" do
+      """
+      defmodule MyTest do
+        test "with timeout" do
+          assert_receive :foo, 1_000
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> assert_issue()
+    end
+
+    test "alerts on assert_receive with a complex pattern and a timeout" do
+      """
+      defmodule MyTest do
+        test "with timeout" do
+          assert_receive {:jump_live_event,
+                          %{
+                            type: :nudge,
+                            delivery: :zoom_app,
+                            call_bot_id: ^call_bot_id,
+                            bot_id: ^bot_id,
+                            payload: ^nudge
+                          }},
+                          1_000
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> assert_issue()
+    end
+
+    test "alerts on assert_receive with a timeout and a failure message" do
+      """
+      defmodule MyTest do
+        test "with timeout and message" do
+          assert_receive :foo, 1_000, "nope"
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> assert_issue()
+    end
+
+    test "alerts on assert_receive with a variable timeout" do
+      """
+      defmodule MyTest do
+        @timeout 1_000
+
+        test "with variable timeout" do
+          assert_receive :foo, @timeout
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> assert_issue()
+    end
+
+    test "does not alert when no timeout is specified" do
+      """
+      defmodule MyTest do
+        test "without timeout" do
+          assert_receive :foo
+          assert_receive {:bar, _}
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> refute_issues()
+    end
+
+    test "does not alert on other assertions" do
+      """
+      defmodule MyTest do
+        test "other assertions" do
+          assert true
+          assert 1 == 1
+          assert_received :foo
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> refute_issues()
+    end
+  end
+
+  describe "with a configured min_assert_receive_timeout" do
+    test "alerts when literal timeout is less than the minimum" do
+      """
+      defmodule MyTest do
+        test "short timeout" do
+          assert_receive :foo, 500
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000)
+      |> assert_issue()
+    end
+
+    test "does not alert when literal timeout equals the minimum" do
+      """
+      defmodule MyTest do
+        test "exactly the minimum" do
+          assert_receive :foo, 1_000
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000)
+      |> refute_issues()
+    end
+
+    test "does not alert when literal timeout exceeds the minimum" do
+      """
+      defmodule MyTest do
+        test "longer than minimum" do
+          assert_receive :foo, 1001
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000)
+      |> refute_issues()
+    end
+
+    test "does not alert when no timeout is specified" do
+      """
+      defmodule MyTest do
+        test "no timeout falls back to default" do
+          assert_receive :foo
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000)
+      |> refute_issues()
+    end
+
+    test "alerts when timeout is a non-literal we cannot statically verify" do
+      """
+      defmodule MyTest do
+        @timeout 500
+
+        test "non-literal timeout cannot be verified" do
+          assert_receive :foo, @timeout
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000)
+      |> assert_issue()
+    end
+  end
+
+  describe "without a configured max_refute_receive_timeout" do
+    test "does not alert on refute_receive with a literal timeout" do
+      """
+      defmodule MyTest do
+        test "refute with timeout" do
+          refute_receive :foo, 5_000
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> refute_issues()
+    end
+
+    test "does not alert on refute_receive without a timeout" do
+      """
+      defmodule MyTest do
+        test "refute without timeout" do
+          refute_receive :foo
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout)
+      |> refute_issues()
+    end
+  end
+
+  describe "with a configured max_refute_receive_timeout" do
+    test "alerts on refute_receive when literal timeout exceeds the maximum" do
+      """
+      defmodule MyTest do
+        test "long refute timeout" do
+          refute_receive :foo, 1_000
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> assert_issue()
+    end
+
+    test "alerts on refute_receive with a long timeout and a failure message" do
+      """
+      defmodule MyTest do
+        test "long refute timeout with message" do
+          refute_receive :foo, 1_000, "nope"
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> assert_issue()
+    end
+
+    test "does not alert when refute_receive timeout equals the maximum" do
+      """
+      defmodule MyTest do
+        test "refute timeout at the max" do
+          refute_receive :foo, 100
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> refute_issues()
+    end
+
+    test "does not alert when refute_receive timeout is below the maximum" do
+      """
+      defmodule MyTest do
+        test "refute timeout below the max" do
+          refute_receive :foo, 50
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> refute_issues()
+    end
+
+    test "alerts when no refute_receive timeout is specified" do
+      """
+      defmodule MyTest do
+        test "refute without timeout" do
+          refute_receive :foo
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> assert_issue()
+    end
+
+    test "alerts when refute_receive timeout is a non-literal we cannot statically verify" do
+      """
+      defmodule MyTest do
+        @timeout 1_000
+
+        test "non-literal refute timeout cannot be verified" do
+          refute_receive :foo, @timeout
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+      |> assert_issue()
+    end
+
+    test "error message references the minimum-bound nature of refute_receive" do
+      [issue] =
+        """
+        defmodule MyTest do
+          test "long refute timeout" do
+            refute_receive :foo, 1_000
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(AssertReceiveTimeout, max_refute_receive_timeout: 100)
+
+      assert issue.message =~ "refute_receive"
+      assert issue.message =~ "minimum"
+      assert issue.message =~ "slow"
+    end
+  end
+
+  describe "with both min_assert_receive_timeout and max_refute_receive_timeout configured" do
+    test "alerts on a short assert_receive and a long refute_receive together" do
+      issues =
+        """
+        defmodule MyTest do
+          test "mixed" do
+            assert_receive :foo, 500
+            refute_receive :bar, 1_000
+          end
+        end
+        """
+        |> to_source_file()
+        |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000, max_refute_receive_timeout: 100)
+
+      assert length(issues) == 2
+    end
+
+    test "does not alert when both timeouts are within their bounds" do
+      """
+      defmodule MyTest do
+        test "ok" do
+          assert_receive :foo, 1_000
+          refute_receive :bar, 50
+        end
+      end
+      """
+      |> to_source_file()
+      |> run_check(AssertReceiveTimeout, min_assert_receive_timeout: 1_000, max_refute_receive_timeout: 100)
+      |> refute_issues()
+    end
+  end
+end


### PR DESCRIPTION
Adds a new check which flags `assert_receive` calls that specify explicit timeouts. These timeouts can seem like a fine idea in dev, but when your test later runs on a dog-slow CI machine, the tight timeouts can cause flakiness. (In CI, you might run with an absurdly long timeout to avoid flakiness.)

Supports an optional `min_assert_receive_timeout` parameter that allows literal `assert_receive` timeouts greater than or equal to the configured minimum. Also supports an optional `max_refute_receive_timeout` parameter that flags `refute_receive` calls whose timeout exceeds the configured maximum (because `refute_receive` always blocks for its full timeout, setting a lower bound on the test's runtime).