### PR TITLE
fix (ConditionalAssertion): Improve error messages

### DIFF
--- a/lib/jump/credo_checks/conditional_assertion.ex
+++ b/lib/jump/credo_checks/conditional_assertion.ex
@@ -1,7 +1,7 @@
 defmodule Jump.CredoChecks.ConditionalAssertion do
   @moduledoc """
   Flags `assert` calls whose top-level expression is a boolean `or`/`||`,
-  since those make the test non-deterministic.
+  since they indicate a lack of clarity about the expected behavior.
   """
 
   use Credo.Check,
@@ -18,11 +18,11 @@ defmodule Jump.CredoChecks.ConditionalAssertion do
       setup is non-deterministic; fix the source of the non-determinism instead
       of papering over it in the assertion.
 
-          # ❌ Non-deterministic
+          # ❌ Unclear expected behavior (or non-deterministic)
           assert foo == :bar or baz == :bop
           assert foo in [:bar, :baz] || bop in [:whiz, :bang]
 
-          # ✅ Deterministic
+          # ✅ Clear, deterministic
           assert foo == :bar
           assert bop in [:whiz, :bang]
       """
@@ -38,16 +38,16 @@ defmodule Jump.CredoChecks.ConditionalAssertion do
   end
 
   defp traverse({:assert, meta, [{op, _, [_, _]} = expr | _rest]} = ast, issues, issue_meta) when op in [:or, :||] do
-    {ast, [issue_for(issue_meta, Macro.to_string(expr), meta[:line]) | issues]}
+    {ast, [issue_for(issue_meta, op, Macro.to_string(expr), meta[:line]) | issues]}
   end
 
   defp traverse(ast, issues, _issue_meta), do: {ast, issues}
 
-  defp issue_for(issue_meta, trigger, line_no) do
+  defp issue_for(issue_meta, op, trigger, line_no) do
     format_issue(
       issue_meta,
       message:
-        "Asserting on an `or`/`||` expression makes the test non-deterministic — it passes for either branch. Assert the specific value you expect.",
+        "Asserting on a conditional (`#{op}`) indicates a lack of clarity about the expected behavior. Assert the specific value you expect.",
       trigger: trigger,
       line_no: line_no
     )

--- a/test/jump/credo_checks/conditional_assertion_test.exs
+++ b/test/jump/credo_checks/conditional_assertion_test.exs
@@ -29,7 +29,15 @@ defmodule Jump.CredoChecks.ConditionalAssertionTest do
         |> to_source_file()
         |> run_check(ConditionalAssertion)
         |> assert_issue(fn issue ->
-          assert issue.message =~ "deterministic"
+          expected_operator =
+            if assertion =~ "or" do
+              "or"
+            else
+              "||"
+            end
+
+          assert issue.message =~ "Asserting on a conditional (`#{expected_operator}`) indicates a lack of clarity about the expected behavior."
+          assert issue.message =~ "Assert the specific value you expect."
         end)
       end
     end

--- a/test/jump/credo_checks/conditional_assertion_test.exs
+++ b/test/jump/credo_checks/conditional_assertion_test.exs
@@ -36,7 +36,9 @@ defmodule Jump.CredoChecks.ConditionalAssertionTest do
               "||"
             end
 
-          assert issue.message =~ "Asserting on a conditional (`#{expected_operator}`) indicates a lack of clarity about the expected behavior."
+          assert issue.message =~
+                   "Asserting on a conditional (`#{expected_operator}`) indicates a lack of clarity about the expected behavior."
+
           assert issue.message =~ "Assert the specific value you expect."
         end)
       end


### PR DESCRIPTION
The error message now indicates the precise form of "or" that caused the problem, and the explanation for why it's bad is improved.