### PR TITLE
feat: Add UndeclaredExternalResource check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -98,6 +98,7 @@
           # Default max_assertions is 20
           {Jump.CredoChecks.TooManyAssertions, [max_assertions: 20]},
           {Jump.CredoChecks.TopLevelAliasImportRequire, []},
+          {Jump.CredoChecks.UndeclaredExternalResource, []},
           {Jump.CredoChecks.UnusedLiveViewAssign, [ignored_assigns: [:active_path]]},
           {Jump.CredoChecks.UseObanProWorker, []},
           {Jump.CredoChecks.VacuousTest,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * New checks:
     * `Jump.CredoChecks.AssertReceiveTimeout`, which flags `assert_receive` calls that specify an explicit timeout. Supports an optional `min_assert_receive_timeout` parameter that allows literal `assert_receive` timeouts greater than or equal to the configured minimum, and an optional `max_refute_receive_timeout` parameter that flags `refute_receive` calls whose timeout exceeds the configured maximum. ([PR](https://github.com/Jump-App/credo_checks/pull/16))
     * `Jump.CredoChecks.ConditionalAssertion`, which flags assertions that include an "or." Tests should be able to confidently assert which branch will be taken every time. ([PR](https://github.com/Jump-App/credo_checks/pull/15))
+    * `Jump.CredoChecks.UndeclaredExternalResource`, which flags module attributes that read from the file system at compile time (e.g., `File.read!/1`) without declaring an `@external_resource`. Without it, editing the file won't trigger a recompile, leaving stale data baked into the module.
 
 ## v0.3.0
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ See the individual modules for detailed descriptions of each check type.
 - `Jump.CredoChecks.DoctestIExExamples`: Ensures that modules with interactive Elixir examples in their docstrings have a corresponding test file that runs those doctests.
 - `Jump.CredoChecks.ForbiddenFunction`: Alerts with a custom error message when particular functions are called.
 - `Jump.CredoChecks.LiveViewFormCanBeRehydrated`: Ensures any form with a `phx-submit` attribute also includes an ID and `phx-change` handler. Without these, LiveView can't maintain frontend form state across deploys/reconnects, leading to the form being totally reset.
+- `Jump.CredoChecks.UndeclaredExternalResource`: Ensures modules that read from the file system at compile time (e.g., `File.read!/1` in a module attribute) declare a corresponding `@external_resource` so that editing the file on disk triggers a recompile.
+
+    ```elixir
+    # ❌ Bad — editing prompt.md won't recompile this module
+    defmodule MyApp.ReadsFromDisk do
+      @prompt_path "priv/data/prompt.md"
+      @prompt File.read!(@prompt_path)
+    end
+
+    # ✅ Good: changes made to prompt.md cause MyApp.ReadsFromDisk to recompile
+    defmodule MyApp.ReadsFromDisk do
+      @prompt_path "priv/data/prompt.md"
+      @external_resource @prompt_path
+      @prompt File.read!(@prompt_path)
+    end
+    ```
 - `Jump.CredoChecks.PreferTextColumns`: Ensures your Ecto migrations use the `:text` column type, rather than `:string`, since there is no performance difference in modern versions of Postgres, and you almost always want to enforce maximum length at the application level instead.
 - `Jump.CredoChecks.TestHasNoAssertions`: Alerts on ExUnit `test` blocks that contain no assertions.
 - `Jump.CredoChecks.TooManyAssertions`: Flags tests that make an excessive number of assertions, generally indicating a test that conflates multiple concerns. Defaults to 20 asserts at max.
@@ -137,6 +153,7 @@ The following instructions assume you already have Credo configured and working 
                  {:erlang, :binary_to_term, "Use Plug.Crypto.non_executable_binary_to_term/2 instead."},
                ]},
               {Jump.CredoChecks.LiveViewFormCanBeRehydrated, excluded: ["lib/my_app/"]},
+              {Jump.CredoChecks.UndeclaredExternalResource, []},
               # Default start_after is "0"
               {Jump.CredoChecks.PreferChangeOverUpDownMigrations, start_after: "20240101000000"},
               {Jump.CredoChecks.PreferTextColumns, start_after: "20240101000000"},

--- a/lib/jump/credo_checks/undeclared_external_resource.ex
+++ b/lib/jump/credo_checks/undeclared_external_resource.ex
@@ -1,0 +1,248 @@
+defmodule Jump.CredoChecks.UndeclaredExternalResource do
+  @moduledoc """
+  Ensures modules that read from the file system at compile time declare
+  `@external_resource`, so they get recompiled when those files change.
+  """
+
+  use Credo.Check,
+    base_priority: :high,
+    category: :warning,
+    explanations: [
+      check: """
+      When a module attribute reads from the file system (via `File.read!/1`,
+      `File.ls!/1`, etc.), the file's contents get baked into the compiled module.
+      Without an `@external_resource` declaration, `mix compile` has no idea the
+      module depends on that file, so editing the file will *not* trigger a
+      recompile and the module will keep stale data until something else forces
+      a rebuild.
+
+          # ❌ Bad — editing prompt.md won't recompile this module
+          defmodule Foo do
+            @prompt_path "priv/data/prompt.md"
+            @prompt File.read!(@prompt_path)
+          end
+
+          # ✅ Good
+          defmodule Foo do
+            @prompt_path "priv/data/prompt.md"
+            @external_resource @prompt_path
+            @prompt File.read!(@prompt_path)
+          end
+
+      When both the paths being read and the `@external_resource` values are
+      hard-coded strings (written inline, held in a module attribute, or built
+      by joining hard-coded strings with `Path.join`), this check also verifies
+      that they match up.
+
+      However, when either side is built dynamically (via variables, other
+      function calls, etc.), the presence of any `@external_resource`
+      declaration in the module satisfies the check.
+      """
+    ]
+
+  alias Credo.IssueMeta
+  alias Credo.SourceFile
+
+  @doc false
+  @impl Credo.Check
+  def run(%SourceFile{filename: filename} = source_file, params \\ []) do
+    if String.ends_with?(filename, ".ex") do
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> SourceFile.ast()
+      |> module_bodies()
+      |> Enum.flat_map(&issues_for_module_body(&1, issue_meta))
+      |> Enum.sort_by(& &1.line_no)
+    else
+      []
+    end
+  end
+
+  defp module_bodies(ast) do
+    ast
+    |> Macro.prewalk([], fn
+      {:defmodule, _meta, [_alias, [do: body]]} = node, acc -> {node, [body | acc]}
+      node, acc -> {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp issues_for_module_body(body, issue_meta) do
+    attrs = attribute_values(body)
+    resources = external_resources(body)
+    resolved_resources = Enum.map(resources, fn {value, _line} -> resolve(value, attrs) end)
+
+    cond do
+      resources == [] ->
+        body
+        |> file_dependent_attributes(attrs)
+        |> Enum.map(fn {name, line, _paths} -> undeclared_issue(name, line, issue_meta) end)
+
+      Enum.all?(resolved_resources, &match?({:literal, _}, &1)) ->
+        declared_paths = Enum.map(resolved_resources, fn {:literal, path} -> path end)
+
+        # When a mismatching @external_resource holds an inline string, point
+        # at it; otherwise point at the attribute doing the reading.
+        inline_resource_line =
+          Enum.find_value(resources, fn {value, line} -> if is_binary(value), do: line end)
+
+        body
+        |> file_dependent_attributes(attrs)
+        |> Enum.flat_map(fn {name, line, paths} ->
+          case paths -- declared_paths do
+            [] -> []
+            uncovered -> [mismatch_issue(name, uncovered, inline_resource_line || line, issue_meta)]
+          end
+        end)
+
+      true ->
+        # At least one @external_resource is built dynamically, so we can't
+        # tell which files it covers.
+        []
+    end
+  end
+
+  # Groups every module attribute assignment in the body by name, so that
+  # `File.read!(@path)` and `@external_resource @path` can be resolved.
+  defp attribute_values(body) do
+    body
+    |> walk_module([], fn
+      {:@, _meta, [{name, _, [value]}]} = node, acc when is_atom(name) -> {node, [{name, value} | acc]}
+      node, acc -> {node, acc}
+    end)
+    |> Enum.group_by(fn {name, _value} -> name end, fn {_name, value} -> value end)
+  end
+
+  # Resolves an expression to {:literal, path} when it's a hard-coded string,
+  # a reference to a module attribute holding one, or a Path.join of such
+  # values; returns :dynamic otherwise. Attributes reassigned to different
+  # values are treated as dynamic.
+  defp resolve(value, attrs), do: resolve(value, attrs, [])
+
+  defp resolve(value, _attrs, _visited) when is_binary(value), do: {:literal, value}
+
+  defp resolve({:@, _, [{name, _, context}]}, attrs, visited) when is_atom(name) and is_atom(context) do
+    with false <- name in visited,
+         [value] <- attrs |> Map.get(name, []) |> Enum.uniq() do
+      resolve(value, attrs, [name | visited])
+    else
+      _ -> :dynamic
+    end
+  end
+
+  defp resolve({{:., _, [{:__aliases__, _, aliases}, :join]}, _, [parts]}, attrs, visited)
+       when aliases in [[:Path], [Elixir, :Path]] and is_list(parts) and parts != [] do
+    join_if_literals(parts, attrs, visited)
+  end
+
+  defp resolve({{:., _, [{:__aliases__, _, aliases}, :join]}, _, [_left, _right] = parts}, attrs, visited)
+       when aliases in [[:Path], [Elixir, :Path]] do
+    join_if_literals(parts, attrs, visited)
+  end
+
+  defp resolve(_value, _attrs, _visited), do: :dynamic
+
+  defp join_if_literals(parts, attrs, visited) do
+    resolved = Enum.map(parts, &resolve(&1, attrs, visited))
+
+    if Enum.all?(resolved, &match?({:literal, _}, &1)) do
+      {:literal, resolved |> Enum.map(fn {:literal, part} -> part end) |> Path.join()}
+    else
+      :dynamic
+    end
+  end
+
+  # Walks a module body without descending into nested defmodules, since each
+  # module needs its own @external_resource declarations.
+  defp walk_module(body, acc, fun) do
+    body
+    |> Macro.prewalk(acc, fn
+      {:defmodule, _meta, _args}, acc -> {nil, acc}
+      node, acc -> fun.(node, acc)
+    end)
+    |> elem(1)
+  end
+
+  defp external_resources(body) do
+    body
+    |> walk_module([], fn
+      {:@, meta, [{:external_resource, _, [value]}]} = node, acc -> {node, [{value, meta[:line]} | acc]}
+      node, acc -> {node, acc}
+    end)
+    |> Enum.reverse()
+  end
+
+  defp file_dependent_attributes(body, attrs) do
+    body
+    |> walk_module([], fn
+      {:@, meta, [{name, _, [value]}]} = node, acc when is_atom(name) and name != :external_resource ->
+        case file_call_paths(value, attrs) do
+          :no_file_calls -> {node, acc}
+          {:file_calls, paths} -> {node, [{name, meta[:line], paths} | acc]}
+        end
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> Enum.reverse()
+  end
+
+  # Returns :no_file_calls, or {:file_calls, paths} where paths are the
+  # hard-coded string paths passed to the file system calls (dynamically built
+  # paths are omitted, since we can't tell what they resolve to).
+  defp file_call_paths(value, attrs) do
+    value
+    |> Macro.prewalk(:no_file_calls, fn
+      {{:., _, [{:__aliases__, _, aliases}, _fun]}, _, args} = node, acc
+      when aliases in [[:File], [Elixir, :File]] ->
+        {node, add_file_call(acc, args, attrs)}
+
+      {{:., _, [:file, _fun]}, _, args} = node, acc ->
+        {node, add_file_call(acc, args, attrs)}
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp add_file_call(acc, args, attrs) do
+    paths =
+      case acc do
+        :no_file_calls -> []
+        {:file_calls, paths} -> paths
+      end
+
+    with [path_arg | _] <- args,
+         {:literal, path} <- resolve(path_arg, attrs) do
+      {:file_calls, [path | paths]}
+    else
+      _ -> {:file_calls, paths}
+    end
+  end
+
+  defp undeclared_issue(name, line_no, issue_meta) do
+    format_issue(
+      issue_meta,
+      message:
+        "Module attribute `@#{name}` reads from the file system at compile time, but the module " <>
+          "never declares `@external_resource`, so editing the file won't trigger a recompile.",
+      trigger: "@#{name}",
+      line_no: line_no
+    )
+  end
+
+  defp mismatch_issue(name, uncovered_paths, line_no, issue_meta) do
+    paths = Enum.map_join(uncovered_paths, ", ", &"\"#{&1}\"")
+
+    format_issue(
+      issue_meta,
+      message:
+        "Module attribute `@#{name}` reads #{paths} at compile time, but no `@external_resource` " <>
+          "declaration matches, so editing the file won't trigger a recompile.",
+      trigger: "@#{name}",
+      line_no: line_no
+    )
+  end
+end

--- a/test/jump/credo_checks/undeclared_external_resource_test.exs
+++ b/test/jump/credo_checks/undeclared_external_resource_test.exs
@@ -1,0 +1,288 @@
+defmodule Jump.CredoChecks.UndeclaredExternalResourceTest do
+  use Credo.Test.Case, async: true
+
+  alias Jump.CredoChecks.UndeclaredExternalResource
+
+  test "alerts when a module attribute reads a file without @external_resource" do
+    """
+    defmodule Foo do
+      @prompt_path "priv/data/prompt.md"
+      @prompt File.read!(@prompt_path)
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@prompt"
+      assert issue.line_no == 3
+    end)
+  end
+
+  test "alerts when hard-coded strings don't match up" do
+    """
+    defmodule Foo do
+      @prompt File.read!("priv/data/prompt.md")
+      @external_resource "priv/data/not-the-same-prompt.md"
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@prompt"
+      assert issue.line_no == 3
+    end)
+  end
+
+  test "alerts when external resources from module attributes don't match up" do
+    """
+    defmodule Foo do
+      @path "priv/data/prompt.md"
+      @prompt File.read!(@path)
+
+      @path2 "priv/data/not-the-same-prompt.md"
+      @external_resource @path2
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@prompt"
+      assert issue.line_no == 3
+    end)
+  end
+
+  test "alerts when external resources from module attributes from function calls don't match up" do
+    """
+    defmodule Foo do
+      @path Path.join("priv", "data/prompt.md")
+      @prompt File.read!(@path)
+
+      @path2 Path.join("priv", "data/not-the-same-prompt.md")
+      @external_resource @path2
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@prompt"
+      assert issue.line_no == 3
+    end)
+  end
+
+  test "alerts when file system access happens in a pipeline or captured function" do
+    """
+    defmodule Foo do
+      @tools_dir Path.expand("../../../tools", __DIR__)
+      @tool_subdirs @tools_dir
+                    |> File.ls!()
+                    |> Enum.filter(&(File.dir?(Path.join(@tools_dir, &1)) and &1 != "core"))
+                    |> Enum.map(&(&1 |> Macro.camelize() |> String.to_atom()))
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@tool_subdirs"
+    end)
+  end
+
+  test "alerts on fully-qualified Elixir.File and Erlang :file calls" do
+    for call <- [
+          ~s{Elixir.File.read!("priv/data/prompt.md")},
+          ~s{:file.read_file("priv/data/prompt.md")}
+        ] do
+      """
+      defmodule Foo do
+        @prompt #{call}
+      end
+      """
+      |> to_source_file()
+      |> run_check(UndeclaredExternalResource)
+      |> assert_issue()
+    end
+  end
+
+  test "alerts once per file-reading attribute" do
+    """
+    defmodule Foo do
+      @prompt File.read!("priv/data/prompt.md")
+      @schema File.read!("priv/data/schema.json")
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issues(fn issues ->
+      assert Enum.map(issues, & &1.trigger) == ["@prompt", "@schema"]
+    end)
+  end
+
+  test "alerts when there's a missing @external_resource attr" do
+    """
+    defmodule Foo do
+      @prompt File.read!("priv/data/prompt.md") |> Jason.decode!()
+      @schema File.read!("priv/data/schema.json")
+      @external_resource "priv/data/prompt.md"
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@schema"
+    end)
+  end
+
+  test "alerts on a nested module that lacks its own @external_resource" do
+    """
+    defmodule Outer do
+      @external_resource "priv/data/outer.md"
+      @outer File.read!("priv/data/outer.md")
+
+      defmodule Inner do
+        @inner File.read!("priv/data/inner.md")
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@inner"
+    end)
+  end
+
+  test "an @external_resource in a nested module does not cover the outer module" do
+    """
+    defmodule Outer do
+      @outer File.read!("priv/data/outer.md")
+
+      defmodule Inner do
+        @external_resource "priv/data/inner.md"
+        @inner File.read!("priv/data/inner.md")
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> assert_issue(fn issue ->
+      assert issue.trigger == "@outer"
+    end)
+  end
+
+  test "does not alert when @external_resource is declared" do
+    """
+    defmodule Foo do
+      @prompt_path "priv/data/prompt.md"
+      @external_resource @prompt_path
+      @prompt File.read!(@prompt_path)
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert when multiple @external_resource attrs are declared" do
+    """
+    defmodule Foo do
+      @prompt_path "priv/data/prompt.md"
+      @external_resource @prompt_path
+      @prompt File.read!(@prompt_path)
+
+      @schema_path "priv/data/schema.json"
+      @external_resource @schema_path
+      @schema File.read!(@schema_path)
+
+      @external_resource "priv/data/not-the-same-schema.json"
+      @schema File.read!("priv/data/not-the-same-schema.json")
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert when external resources from module attributes from function calls match up" do
+    """
+    defmodule Foo do
+      @path Path.join("priv", "data/prompt.md")
+      @prompt File.read!(@path)
+      @external_resource @path
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert when @external_resource is declared inside a comprehension" do
+    """
+    defmodule Foo do
+      @tools_dir Path.expand("../../../tools", __DIR__)
+      @tools_files File.ls!(@tools_dir)
+
+      for file <- @tools_files do
+        @external_resource file
+      end
+
+      @tool_subdirs @tools_files
+                    |> Enum.filter(&(File.dir?(Path.join(@tools_dir, &1)) and &1 != "core"))
+                    |> Enum.map(&(&1 |> Macro.camelize() |> String.to_atom()))
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert on file system access inside function bodies" do
+    """
+    defmodule Foo do
+      def read_prompt do
+        File.read!("priv/data/prompt.md")
+      end
+
+      defp list_tools(dir) do
+        dir |> File.ls!() |> Enum.sort()
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert on module attributes that don't touch the file system" do
+    """
+    defmodule Foo do
+      @moduledoc "Call File.read!/1 at your peril"
+      @prompt_path Path.expand("priv/data/prompt.md")
+      @timeout :timer.seconds(5)
+      @names Enum.map([:a, :b], &Atom.to_string/1)
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert on modules named like File" do
+    """
+    defmodule Foo do
+      @config MyApp.File.parse("priv/data/config.txt")
+    end
+    """
+    |> to_source_file()
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+
+  test "does not alert in .exs files, which mix compile does not track" do
+    """
+    defmodule FooTest do
+      @fixture File.read!("test/fixtures/data.json")
+    end
+    """
+    |> to_source_file("test/foo_test.exs")
+    |> run_check(UndeclaredExternalResource)
+    |> refute_issues()
+  end
+end


### PR DESCRIPTION
Adds a new check to ensure modules that read from the file system at compile time (e.g., `File.read!/1` in a module attribute) declare a corresponding `@external_resource` so that editing the file on disk triggers a recompile.

The initial version of the check is somewhat limited. In the most general case, all it can do is ensure that if you have a `File` dependency in your module attrs, you also have _some_ `@external_resource` declaration. However, for the most common (simplest) cases, it goes a step farther and ensures that a file read of a file path we can easily interpret has a corresponding external resource declaration.