### PR TITLE
fix (UnusedLiveViewAssign): Recognize piped Map.get/{2,3} as a read

### DIFF
--- a/lib/jump/credo_checks/unused_live_view_assign.ex
+++ b/lib/jump/credo_checks/unused_live_view_assign.ex
@@ -314,6 +314,26 @@ defmodule Jump.CredoChecks.UnusedLiveViewAssign do
     if assigns_ast?(assigns_ast), do: literal_keys(key), else: []
   end
 
+  defp read_keys(
+         {:|>, _meta,
+          [assigns_ast, {{:., _dot_meta, [{:__aliases__, _, [:Map]}, function_name]}, _call_meta, [key | _rest]}]}
+       )
+       when function_name in @map_read_functions do
+    if assigns_ast?(assigns_ast), do: literal_keys(key), else: []
+  end
+
+  defp read_keys(
+         {:|>, _meta, [assigns_ast, {{:., _dot_meta, [{:__aliases__, _, [:Access]}, :get]}, _call_meta, [key | _rest]}]}
+       )
+       when is_atom(key) do
+    if assigns_ast?(assigns_ast), do: [key], else: []
+  end
+
+  defp read_keys({:|>, _meta, [assigns_ast, {{:., _dot_meta, [Access, :get]}, _call_meta, [key | _rest]}]})
+       when is_atom(key) do
+    if assigns_ast?(assigns_ast), do: [key], else: []
+  end
+
   defp read_keys({:=, _meta, [map_pattern, assigns_ast]}) do
     if assigns_ast?(assigns_ast) or assigns_binding_ast?(assigns_ast), do: map_pattern_keys(map_pattern), else: []
   end

--- a/test/jump/credo_checks/unused_live_view_assign_test.exs
+++ b/test/jump/credo_checks/unused_live_view_assign_test.exs
@@ -242,6 +242,53 @@ defmodule Jump.CredoChecks.UnusedLiveViewAssignTest do
     })
   end
 
+  test "recognizes Map.get/{2,3} calls as reads" do
+    """
+    defmodule SampleLive do
+      use SampleWeb, :live_view
+
+      def mount(params, _session, socket) do
+        socket
+        |> assign(:used_1, params)
+        |> assign(:used_2, params)
+        |> assign(:used_3, params)
+        |> assign(:used_4, params)
+      end
+
+      def handle_event("some_event", params, socket) do
+        socket
+        |> read_from_assigns_1()
+        |> read_from_assigns_2()
+        |> read_from_assigns_3()
+        |> read_from_assigns_4()
+      end
+
+      defp read_from_assigns_1(%{assigns: assigns}) do
+        assigns
+        |> Map.get(:used_1)
+        |> IO.inspect()
+      end
+
+      defp read_from_assigns_2(%{assigns: assigns}) do
+        assigns
+        |> Map.get(:used_2, %{})
+        |> IO.inspect()
+      end
+
+      defp read_from_assigns_3(%{assigns: assigns}) do
+        Map.get(assigns, :used_3)
+      end
+
+      defp read_from_assigns_4(%{assigns: assigns}) do
+        Map.get(assigns, :used_4, %{})
+      end
+    end
+    """
+    |> to_source_file()
+    |> run_check(UnusedLiveViewAssign)
+    |> refute_issues()
+  end
+
   test "does not treat keyword values in piped assign/3 as assign keys" do
     """
     defmodule SampleLive do


### PR DESCRIPTION
This fixes an oversight in the previous implementation where we didn't recognize `Map.get/{2,3}` calls as a read from `assigns` when they were part of a pipe chain.