### PR TITLE
Add zizmor GitHub Actions audit gate

### DIFF
--- a/.github/actions/elixir-setup/action.yml
+++ b/.github/actions/elixir-setup/action.yml
@@ -57,14 +57,14 @@ runs:
   using: "composite"
   steps:
     - name: Setup elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       id: beam
       with:
         elixir-version: ${{ inputs.elixir-version }}
         otp-version: ${{ inputs.otp-version }}
 
     - name: Get deps cache
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       with:
         path: deps/
         key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
@@ -72,7 +72,7 @@ runs:
           deps-${{ inputs.cache-key }}-${{ runner.os }}-
 
     - name: Get build cache
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       id: build-cache
       with:
         path: _build/${{env.MIX_ENV}}/
@@ -81,7 +81,7 @@ runs:
           build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
 
     - name: Get Hex cache
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
       id: hex-cache
       with:
         path: ~/.hex
@@ -127,6 +127,8 @@ runs:
       if: inputs.build-deps == 'true'
 
     - name: Compile Application
-      run: mix compile ${{ inputs.build-flags }}
+      run: mix compile ${INPUTS_BUILD_FLAGS}
       shell: sh
       if: inputs.build-app == 'true'
+      env:
+        INPUTS_BUILD_FLAGS: ${{ inputs.build-flags }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,25 @@
 version: 2
 updates:
 - package-ecosystem: mix
+  # Wait a week before picking up a new release, so a compromised or yanked
+  # version is not pulled in the moment it is published.
+  cooldown:
+    default-days: 7
   directory: "/"
   schedule:
     interval: weekly
     time: "12:00"
   open-pull-requests-limit: 10
+
+# Keeps the SHA-pinned `uses:` clauses in .github fresh. Without an updater,
+# hash pinning trades a floating-tag problem for a silently-stale-pin problem.
+- package-ecosystem: github-actions
+  cooldown:
+    default-days: 7
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    github-actions:
+      patterns: ["*"]
+  open-pull-requests-limit: 3

--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - '*'
 
+# Checkout is the only thing that touches the repository; nothing calls the
+# GitHub API. The org default is write, which every job would otherwise inherit.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and test
@@ -21,7 +26,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup
@@ -37,7 +44,7 @@ jobs:
       # Optional, but Codecov has a bot that will comment on your PR with per-file
       # coverage deltas.
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./cover/excoveralls.json

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - '*'
 
+# Checkout is the only thing that touches the repository; nothing calls the
+# GitHub API. The org default is write, which every job would otherwise inherit.
+permissions:
+  contents: read
+
 jobs:
   quality_checks:
     name: Formatting, Credo, and Unused Deps
@@ -19,7 +24,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
+        with:
+          persist-credentials: false
 
       - name: Setup Elixir Project
         uses: ./.github/actions/elixir-setup

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,69 @@
+name: Zizmor
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      ZIZMOR_VERSION: "1.29.0"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # `main` is kept at zero high-severity findings, so a red check means the
+      # finding comes from this PR.
+      #
+      # GH_TOKEN enables the online audits. Without it zizmor runs offline,
+      # skips the known-vulnerable-action and stale-ref lookups, and still
+      # reports green.
+      - name: Audit GitHub Actions workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          uvx "zizmor@${ZIZMOR_VERSION}"
+          --format=github
+          --persona=regular
+          --collect=workflows,actions
+          --min-severity=high
+          .
+
+      - name: Remediation guidance
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## ❌ Actions audit failed
+
+          zizmor found a high-severity finding in this repository's GitHub Actions
+          configuration. Findings are annotated inline on the diff; the full list is in
+          the step log above.
+
+          **To fix:** run `uvx zizmor@1.29.0 .` locally to reproduce. Most findings have
+          an auto-fix — `uvx zizmor@1.29.0 --fix=safe .` applies the safe subset. Always
+          read the resulting diff before committing; `--fix=all` is unsafe and has broken
+          workflows in this org before.
+
+          **To request an exception:** add a file-level entry to `.github/zizmor.yml`
+          with a comment justifying it. Line-anchored entries (`file.yml:LINE`) are
+          forbidden — they stop matching when a line shifts, which turns an unrelated PR
+          red for a finding it did not introduce.
+          EOF


### PR DESCRIPTION
Wave 3 of the org-wide zizmor rollout. Follows the pilot in [Jump-App/infrastructure#503](https://github.com/Jump-App/infrastructure/pull/503).

**12 findings → 0.**

## The one that mattered

The `elixir-setup` composite action ran:

```yaml
run: mix compile ${{ inputs.build-flags }}
```

That expands the input into the command text *before* the shell sees it, so anything in `build-flags` executes. It now arrives via `env:` and the run body reads `${INPUTS_BUILD_FLAGS}` — deliberately **unquoted**, because `build-flags` is a list of flags that has to word-split.

This one had to be fixed rather than documented: zizmor cannot suppress findings inside composite actions from `.github/zizmor.yml` at all, so there is no exception path for it.

## The rest

- Every action pinned to a hash, including the three `actions/cache` uses and `erlef/setup-beam` inside the composite action. Every SHA verified against the API.
- `persist-credentials: false` on the checkouts — nothing after checkout talks to a remote.
- `permissions: contents: read` on both workflows, which had no block and so inherited the org default of write.
- A 7-day cooldown on the existing `mix` ecosystem, plus a `github-actions` ecosystem so the new pins have an updater.

**Pins stay on their existing majors** — `actions/checkout` is still v2, `actions/cache` still v3. This is not a version bump; Dependabot can propose those now that it is watching.

## The gate

Runs on every PR and on pushes to `main`, at `--min-severity=high`. Straight to blocking rather than advisory — the backlog is cleared in this same PR.

Note this repo's ruleset (`CI passes`, 14975020) requires three contexts today. Adding `Zizmor` to that list needs repo admin, which I don't have, so the check will run without being required until someone adds it.

## Verification

- zizmor: **0 findings** after the change, online audits on, all collectors.
- Every hash pin re-checked against the GitHub API, dereferencing annotated tags.
- All changed YAML parses, including the composite action.
- No workflow runs were triggered to produce this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)